### PR TITLE
Use Tools CDNJS instead of Google / CDNJS

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 	<title>Media Report simplifier</title>
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+	<script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jquery/2.1.4/jquery.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/tinysort/2.2.4/tinysort.js"></script>
-    <link rel="stylesheet" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
+    <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/jqueryui/1.11.4/jquery-ui.js"></script>
+    <script src="https://tools-static.wmflabs.org/cdnjs/ajax/libs/tinysort/2.2.4/tinysort.js"></script>
     
 	<script src="newscript.js"></script>
 	<script src="moment.js"></script>


### PR DESCRIPTION
This brings it in compliance with Tool Labs' privacy policy.

Right now this is leaking the IP address of anyone who visits to both 
Google and Cloudflare.